### PR TITLE
How it works section

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -179,19 +179,19 @@ section .content {
 .talks-section .topic-list
 {
   display: block;
-  min-height: 240px;
+  min-height: 100px;
 }
 .talks-section .topic-list div:first-child
 {
   float: left;
   width: 50%;
-  min-height: 200px;
+  min-height: 100px;
 }
 .talks-section .topic-list div:last-child
 {
   float: right;
   width: 50%;
-  min-height: 200px;
+  min-height: 100px;
 }
 
 .schedule-section table{

--- a/index.html
+++ b/index.html
@@ -43,60 +43,47 @@
 
   <pg-section>
     <h1>Vision</h1>
-    <p>Polyglot: knowing or using several languages.  We hope to gather Edmonton software developers who will leave language, platform and possibly even editor wars behind and come together for a spontaneously organized day of amazing talks, round-table discussions, panel sessions, and coding.  If you've never been to an unconference (or open-space) event before, you owe it to yourself to make it to Polyglot YEG 2018. It's an experience like no other.</p>
+    <p>Polyglot: knowing or using several languages.  We hope to gather Edmonton software developers who will leave language, platform and possibly even editor wars behind and come together for a spontaneously organized day of amazing talks, round-table discussions, panel sessions, and coding.  If you've never been to an unconference (or open-space) event before, you owe it to yourself to make it to Polyglot YEG. It's an experience like no other.</p>
 
     <p>This event is inspired by the <a href="https://www.polyglotconf.com/">Polyglot Unconference</a> in Vancouver.</p>
     <pg-tickets></pg-tickets>
   </pg-section>
 
-  <pg-section>
-    <h1>Who are we?</h1>
-    <p>Polyglot YEG isn't the product of some faceless corporation looking to make a buck by getting you to a conference and then selling you a time-share. The organizers are all community members from around Edmonton: just like you! We saw a lot of user groups for Javascript, Ruby, Python, functional languages, .net, etc. but very few places where developers from different communities could get together. We hope that Polyglot YEG will be that place: a place for technologists to get together and talk about the craft.</p>
-  </pg-section>
-
   <pg-section class="talks-section">
-    <h1>Talks</h1>
-    <p>
-      Open-space unconferences are spontaneously scheduled and 100% attendee-driven. Sessions will be proposed, selected, and organised at the opening of the conference. We also encourage attendees to suggest and discuss ideas in advance.
-    </p>
+  <pg-section>
+    <h1>How it works</h1>
+    <p>Open-space unconferences are spontaneously scheduled and 100% attendee-driven. Sessions will be proposed and selected at the opening of the conference.</p>
+
+    <p>In the morning attendees can propose or request a session by filling out a provided sheet like so:</p>
+      <ul>
+        <li>Topic:       ____________</li>
+        <li>Proposed by: ____________</li>
+        <li>Format:      ____________</li>
+      </ul>
+    </ol>
+    <p>Sessions will then be selected by dot voting. PolyglotYEG gremlins will put together the schedule based on the votes.</p>
 
     <p>
-      Talks can be on any topic that is even vaguely related to technology. It can be on a hard technical topic or on a soft topic like "Having Empathy". They should be between 30 and 45 minutes long. We'll have projectors and a bunch of adaptors, just bring a laptop if you want use them. Sessions aren't limited to talks&mdash;here are some <a href="http://www.environmentalevaluators.net/ideas-for-designing-and-leading-sessions">unconference session ideas</a>. The organisers have the right to decline any topics that are not relevant or that are potentially inappropriate.
-    </p>
-
-    <p>
-      Some of the talks we've seen mentioned are:
+      Example sessions:
     </p>
     <div class="topic-list">
       <div>
         <ul>
           <li>
-            Version control with git
+            Panel discussion on version control
           </li>
           <li>
-            SOLID principles
+            Presentation on Tor
           </li>
           <li>
-            Tor
-          </li>
-          <li>
-            Event based programming
-          </li>
-          <li>
-            boost::asio
-          </li>
-          <li>
-            py.test
-          </li>
-          <li>
-            Design for Developers
+            Live coding intro to TypeScript
           </li>
         </ul>
       </div>
       <div>
         <ul>
           <li>
-            Kubernetes
+            Overview of Kubernetes
           </li>
           <li>
             Deploying websites to Azure
@@ -104,20 +91,24 @@
           <li>
             Getting started with messaging
           </li>
-          <li>
-            The new, open Microsoft
-          </li>
-          <li>
-            Continuous deployment: a primer
-          </li>
-          <li>
-            Intro to TypeScript
-          </li>
-
         </ul>
       </div>
     </div>
   </pg-section>
+    <!--<p>-->
+      <!-- We also encourage attendees to suggest and discuss ideas in advance.-->
+    <!--</p>-->
+
+    <!--<p>-->
+      <!--Talks can be on any topic that is even vaguely related to technology. It can be on a hard technical topic or on a soft topic like "Having Empathy". They should be between 30 and 45 minutes long. We'll have projectors and a bunch of adaptors, just bring a laptop if you want use them. Sessions aren't limited to talks&mdash;here are some <a href="http://www.environmentalevaluators.net/ideas-for-designing-and-leading-sessions">unconference session ideas</a>. The organisers have the right to decline any topics that are not relevant or that are potentially inappropriate.-->
+    <!--</p>-->
+  <!--</pg-section>-->
+
+  <pg-section>
+    <h1>Who are we?</h1>
+    <p>Polyglot YEG isn't the product of some faceless corporation looking to make a buck by getting you to a conference and then selling you a time-share. The organizers are all community members from around Edmonton: just like you! We saw a lot of user groups for Javascript, Ruby, Python, functional languages, .net, etc. but very few places where developers from different communities could get together. We hope that Polyglot YEG will be that place: a place for technologists to get together and talk about the craft.</p>
+  </pg-section>
+
 
   <pg-section>
     <h1>Code of Conduct</h1>

--- a/index.html
+++ b/index.html
@@ -50,7 +50,6 @@
   </pg-section>
 
   <pg-section class="talks-section">
-  <pg-section>
     <h1>How it works</h1>
     <p>Open-space unconferences are spontaneously scheduled and 100% attendee-driven. Sessions will be proposed and selected at the opening of the conference.</p>
 

--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
         <li>Format:      ____________</li>
       </ul>
     </ol>
-    <p>Sessions will then be selected by dot voting. PolyglotYEG gremlins will put together the schedule based on the votes.</p>
+    <p>Sessions will then be selected by <a href="https://en.wikipedia.org/wiki/Dot-voting" target="_blank">dot voting</a>. PolyglotYEG gremlins will put together the schedule based on the votes.</p>
 
     <p>
       Example sessions:

--- a/index.html
+++ b/index.html
@@ -95,14 +95,6 @@
       </div>
     </div>
   </pg-section>
-    <!--<p>-->
-      <!-- We also encourage attendees to suggest and discuss ideas in advance.-->
-    <!--</p>-->
-
-    <!--<p>-->
-      <!--Talks can be on any topic that is even vaguely related to technology. It can be on a hard technical topic or on a soft topic like "Having Empathy". They should be between 30 and 45 minutes long. We'll have projectors and a bunch of adaptors, just bring a laptop if you want use them. Sessions aren't limited to talks&mdash;here are some <a href="http://www.environmentalevaluators.net/ideas-for-designing-and-leading-sessions">unconference session ideas</a>. The organisers have the right to decline any topics that are not relevant or that are potentially inappropriate.-->
-    <!--</p>-->
-  <!--</pg-section>-->
 
   <pg-section>
     <h1>Who are we?</h1>


### PR DESCRIPTION
Things I did:

1. I moved the "Who are we" section lower down, as it seems less important than how the conference works.

2. Removed references to 2018 as this will actually be in 2019

3. Switched out the "Talks" section for a "How it works" section

4. Changed the vague session examples out for more filled out ones that have not only the topic, but the format as well. (ie. instead of "Git and version control", "Panel discussion on version control")

Before:
<img width="906" alt="polyglot_yeg" src="https://user-images.githubusercontent.com/4259190/49560847-48523300-f8d1-11e8-8ad8-54b700159d54.png">


After:
<img width="917" alt="polyglot_yeg" src="https://user-images.githubusercontent.com/4259190/49561020-4177f000-f8d2-11e8-83aa-334ce9968e71.png">

